### PR TITLE
#23 Create PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,11 @@
+## Description 
+
+...
+
+*  
+* 
+* 
+
+Fixes #
+
+## Review Notes


### PR DESCRIPTION
## Description 

* Creates default PR template for all ORBIT repos.
* If a repo has its own `pull_request_template`, it will take precedent.
* This setup lets us have a simple starting point that we can build on per repo if we want to get into subtemplates.

Fixes  [#23](https://github.com/USSF-ORBIT/ussf-portal/issues/23)

## Review Notes
Extremely meta -- I'm using the template _in this PR_! 

Anything else you'd like to see included? Are the headings clear?

